### PR TITLE
feat: `chats` 도메인 마이그레이션 및 DI 적용

### DIFF
--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -1,116 +1,18 @@
-import asyncio
-from typing import AsyncGenerator
-from fastapi import APIRouter, Depends, HTTPException, Header
-from langchain_upstage import ChatUpstage
-from openai import AsyncOpenAI
+from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi.responses import JSONResponse
 from starlette.responses import StreamingResponse
 
-from app.crud import get_history, list_chats, save_msg, update_chat_title, upsert_chat
+from app.core.deps import inject
 from app.dependencies import get_workflow_stream
-from app.schemas.chat import (ChatContentDTO, ChatDetailResponse, ChatHistoryDTO,
-                              ChatListResponse, ChatPreviewDTO, ChatRequest,
-                              ChatResponseDTO)
-
-from fastapi.encoders import jsonable_encoder
+from app.schemas.chat import (ChatDetailResponse, ChatListResponse, ChatRequest)
 
 from dotenv import load_dotenv
 
-import os
-import json
+from domains.chat.services import ChatService
 
 load_dotenv()
 
 router = APIRouter(prefix="")
-
-UPSTAGE_API_KEY = os.getenv("UPSTAGE_API_KEY", "")
-
-openai_client = AsyncOpenAI(
-    api_key=UPSTAGE_API_KEY,
-    base_url="https://api.upstage.ai/v1",
-)
-
-
-async def generate_chat_title(chat_id: str, question: str) -> str:
-    system_prompt = ("다음 사용자 질문에서 짧고 요약된 대화 제목을 한 문장으로 만들어주세요. "
-                     "20자 이내로 간결하게 작성해주세요.")
-
-    response = await openai_client.chat.completions.create(
-        model="solar-pro",
-        messages=[{
-            "role": "system",
-            "content": system_prompt
-        }, {
-            "role": "user",
-            "content": question
-        }],
-        temperature=0.3,
-        max_tokens=30,
-    )
-
-    title = response.choices[0].message.content or "새로운 대화"
-    update_chat_title(chat_id, title)
-
-    print("- 질문: ", question, ", 제목: ", title)
-
-    return title
-
-
-async def chat_events(req: ChatRequest, run_stream) -> AsyncGenerator[str, None]:
-
-    chat_id = upsert_chat(req.chat_id, "새로운 대화")
-
-    title_task = None
-    if not req.chat_id:
-        title_task = asyncio.create_task(generate_chat_title(chat_id, req.message))
-
-    user_content = ChatContentDTO(message=req.message)
-    save_msg(chat_id, "user", jsonable_encoder(user_content))
-
-    products = []
-    reply_chunks = []
-
-    initial_response = ChatResponseDTO(chat_id=chat_id,
-                                       status="pending",
-                                       content=ChatContentDTO(message="질문을 이해하고 있습니다."))
-
-    data_json = json.dumps(jsonable_encoder(initial_response), ensure_ascii=False)
-    yield f"data: {data_json}\n\n"
-
-    title_yielded = False
-
-    async for _, chunk in run_stream(req.message, chat_id):
-        payload = ChatResponseDTO(**chunk)
-        data_json = json.dumps(jsonable_encoder(payload), ensure_ascii=False)
-
-        yield f"data: {data_json}\n\n"
-
-        match payload:
-            case ChatResponseDTO(status="response",
-                                 content=ChatContentDTO(products=None,
-                                                        message=reply_chunk)):
-                reply_chunks.append(reply_chunk)
-
-            case ChatResponseDTO(status="response",
-                                 content=ChatContentDTO(products=_products)):
-                products = _products
-
-        if not title_yielded and title_task and title_task.done():
-            try:
-                title = title_task.result()
-            except Exception:
-                title = "새로운 대화"
-
-            _send_title = ChatResponseDTO(chat_id=chat_id,
-                                          status="title",
-                                          content=ChatContentDTO(message=title))
-            yield f"data: {json.dumps(jsonable_encoder(_send_title), ensure_ascii=False)}\n\n"
-
-            title_yielded = True
-
-    assistant_content = ChatContentDTO(message="".join(reply_chunks), products=products)
-    save_msg(chat_id, "assistant", jsonable_encoder(assistant_content))
-
-    yield "data: [DONE]\n\n"
 
 
 @router.post("", response_class=StreamingResponse)

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -16,30 +16,45 @@ router = APIRouter(prefix="")
 
 
 @router.post("", response_class=StreamingResponse)
-async def stream_chat(
-        body: ChatRequest,
-        last_event_id: str | None = Header(None, convert_underscores=False),
-        run_stream=Depends(get_workflow_stream),
-):
+async def stream_chat(req: Request,
+                      body: ChatRequest,
+                      last_event_id: str | None = Header(None,
+                                                         convert_underscores=False),
+                      run_stream=Depends(get_workflow_stream),
+                      chat_service: ChatService = Depends(inject(ChatService))):
+
     headers = {"Cache-Control": "no-cache"}
 
     return StreamingResponse(
-        chat_events(body, run_stream),
+        chat_service.chat_events(chat_id=body.chat_id,
+                                 user_id=req.state.user_id,
+                                 message=body.message,
+                                 run_stream=run_stream),
         media_type="text/event-stream",
         headers=headers,
     )
 
 
 @router.get("", response_model=ChatListResponse)
-async def get_chat_list(offset: int = 0, size: int = 20):
-    rows = list_chats(offset, size)
-    return ChatListResponse(size=len(rows),
-                            offset=offset,
-                            items=[ChatPreviewDTO(**r) for r in rows])
+async def get_chat_list(req: Request,
+                        offset: int = 0,
+                        size: int = 20,
+                        chat_service: ChatService = Depends(inject(ChatService))):
+
+    #rows = list_chats(offset, size)
+    rows = await chat_service.get_chat_list(user_id=req.state.user_id,
+                                            size=size,
+                                            offset=offset)
+
+    return ChatListResponse(size=len(rows), offset=offset, items=rows)
 
 
 @router.get("/{chat_id}", response_model=ChatDetailResponse)
-async def get_chat_detail(chat_id: str, offset: int = 0, size: int = 20):
+async def get_chat_detail(chat_id: str,
+                          offset: int = 0,
+                          size: int = 20,
+                          chat_service: ChatService = Depends(inject(ChatService))):
+    """
     rows = get_history(chat_id, offset, size)
     if not rows:
         raise HTTPException(status_code=404, detail="chat not found")
@@ -47,3 +62,15 @@ async def get_chat_detail(chat_id: str, offset: int = 0, size: int = 20):
         ChatHistoryDTO(role=r["role"], content=json.loads(r["content"])) for r in rows
     ]
     return ChatDetailResponse(size=len(items), offset=offset, items=items)
+    """
+
+    chat = await chat_service.get_chat_detail(chat_id)
+    if not chat:
+        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND,
+                            content={"detail": "Chat does not exists"})
+
+    return ChatDetailResponse(
+        size=len(chat.messages),
+        offset=offset,
+        items=chat.messages,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,8 @@ class MongoCollections:
     tickets: str = field(
         default_factory=lambda: os.getenv("COL_LOGIN_TICKETS", "login_tickets"))
 
+    chats: str = field(default_factory=lambda: os.getenv("COL_CHATS", "chats"))
+
 
 @dataclass(frozen=True)
 class MongoConfig:

--- a/backend/app/core/container.py
+++ b/backend/app/core/container.py
@@ -7,6 +7,8 @@ from domains.auth.repositories import TokenRepository, TicketRepository
 from domains.auth.services import KakaoOAuthService, TicketService, TokenService
 
 from domains.auth.usecases import KakaoAuthUseCase
+from domains.chat.repositories import ChatRepository
+from domains.chat.services import ChatService
 from domains.user.repositories import SocialRepository, UserRepository
 from domains.user.services import UserService
 
@@ -127,6 +129,16 @@ async def init_container() -> AppContainer:
             token_service=_c.resolve(TokenService),
             ticket_service=_c.resolve(TicketService),
         ))
+
+    c.register(
+        ChatRepository, lambda _c: ChatRepository(
+            cfg=_c.resolve(AppConfig),
+            db=_c.resolve(AsyncIOMotorDatabase),
+        ))
+    c.register(
+        ChatService, lambda _c: ChatService(cfg=_c.resolve(AppConfig),
+                                            user_repo=_c.resolve(UserRepository),
+                                            chat_repo=_c.resolve(ChatRepository)))
 
     #await c.resolve(TicketRepository).ensure_indexes()
 

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel, Field
 from pytz import timezone
 
 from app.schemas.product import PartialProductInfoDTO, ProductInfoDTO
+from domains.chat.models import ChatMessage, ChatProductInfo, ChatProductPartialInfo
+from domains.chat.repositories import ChatPreviewDTO
 
 
 class ChatRequest(BaseModel):
@@ -14,7 +16,9 @@ class ChatRequest(BaseModel):
 
 class ChatContentDTO(BaseModel):
     message: Optional[str] = None
-    products: Optional[Union[List[ProductInfoDTO], List[PartialProductInfoDTO]]] = None
+    #products: Optional[Union[List[ProductInfoDTO], List[PartialProductInfoDTO]]] = None
+    products: Optional[Union[List[ChatProductInfo],
+                             List[ChatProductPartialInfo]]] = None
 
 
 ChatResponseStatus = Literal["pending", "title", "response", "failed", "stop"]
@@ -42,9 +46,10 @@ class ChatDetailResponse(BaseModel):
 
     size: int
     offset: int
-    items: List[ChatHistoryDTO]
+    items: List[ChatMessage]
 
 
+"""
 class ChatPreviewDTO(BaseModel):
 
     chat_id: str
@@ -58,6 +63,7 @@ class ChatPreviewDTO(BaseModel):
                 lambda v: v.astimezone(timezone('Asia/Seoul')).isoformat(
                     timespec='milliseconds').replace('+00:00', 'Z')
         }
+"""
 
 
 class ChatListResponse(BaseModel):

--- a/backend/domains/auth/services.py
+++ b/backend/domains/auth/services.py
@@ -18,6 +18,9 @@ class InvalidTokenError(Exception):
     pass
 
 
+TokenPair = TypedDict("TokenPair", {"access_token": str, "refresh_token": str})
+
+
 class TokenService:
 
     def __init__(self, *, cfg: AppConfig, token_repo: TokenRepository):
@@ -29,7 +32,7 @@ class TokenService:
         payload = {"exp": expire, "sub": sub}
         return jwt.encode(payload, self.auth.secret_key, algorithm=self.auth.algorithm)
 
-    async def issue_new_token_pair(self, user_id: str) -> Dict[str, str]:
+    async def issue_new_token_pair(self, user_id: str) -> TokenPair:
         """액세스 토큰과 리프레시 토큰 쌍 발급 및 DB 저장"""
         access_token_expires = timedelta(minutes=self.auth.access_token_expire_minutes)
         refresh_token_expires = timedelta(days=self.auth.refresh_token_expire_days)

--- a/backend/domains/auth/services.py
+++ b/backend/domains/auth/services.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import hashlib
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional, TypedDict
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 import uuid
@@ -34,6 +34,7 @@ class TokenService:
 
     async def issue_new_token_pair(self, user_id: str) -> TokenPair:
         """액세스 토큰과 리프레시 토큰 쌍 발급 및 DB 저장"""
+
         access_token_expires = timedelta(minutes=self.auth.access_token_expire_minutes)
         refresh_token_expires = timedelta(days=self.auth.refresh_token_expire_days)
 
@@ -47,7 +48,8 @@ class TokenService:
             access_token_expires_at=datetime.now(timezone.utc) + access_token_expires,
             refresh_token_expires_at=datetime.now(timezone.utc) + refresh_token_expires)
 
-        await self.token_repo.upsert_tokens(token_model.model_dump())
+        #await self.token_repo.upsert_tokens(token_model.model_dump())
+        await self.token_repo.insert_token(token_model)
 
         return {"access_token": at, "refresh_token": rt}
 
@@ -90,7 +92,9 @@ class TokenService:
                 datetime.now(timezone.utc) + access_token_expires,
         }
 
-        await self.token_repo.upsert_tokens({"user_id": user_id, **update_data})
+        await self.token_repo.upsert_tokens(user_id=user_id,
+                                            refresh_token=refresh_token,
+                                            new_data=update_data)
 
         return new_at
 

--- a/backend/domains/chat/models.py
+++ b/backend/domains/chat/models.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from typing import List, Literal, Optional
+import uuid
+from pydantic import BaseModel, Field
+
+
+class ChatProductOption(BaseModel):
+    category: str
+    value: str
+
+
+class ChatProductPartialInfo(BaseModel):
+
+    name: str
+
+    product_type: Literal["saving", "deposit", "card", "insurance"]
+    product_id: Optional[str] = None
+
+    description: Optional[str] = None
+    institution: str
+
+    options: Optional[List[ChatProductOption]] = None
+    tags: Optional[List[str]] = None
+    details: Optional[str] = None
+
+
+class ChatProductInfo(BaseModel):
+
+    name: str
+
+    product_type: Literal["saving", "deposit", "card", "insurance"]
+    product_id: Optional[str] = None
+
+    description: str
+    institution: str
+
+    options: List[ChatProductOption]
+    tags: List[str] = []
+    details: str
+
+
+class ChatContent(BaseModel):
+
+    message: Optional[str] = None
+    products: Optional[List[ChatProductInfo]] = None
+
+
+class ChatMessage(BaseModel):
+
+    role: Literal["user", "assistant"]
+    content: ChatContent
+
+
+class Chat(BaseModel):
+
+    id: str = Field(alias="_id",
+                    default_factory=lambda _: str(uuid.uuid4()),
+                    frozen=True)
+
+    user_id: str
+
+    title: Optional[str] = None
+    messages: List[ChatMessage] = []
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/domains/chat/repositories.py
+++ b/backend/domains/chat/repositories.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo.results import UpdateResult
+from app.core.config import AppConfig
+from domains.chat.models import Chat, ChatMessage
+
+
+@dataclass
+class ChatPreviewDTO:
+
+    chat_id: str
+    title: str
+
+    created_at: datetime
+    updated_at: datetime
+
+
+class ChatRepository:
+
+    def __init__(self, *, cfg: AppConfig, db: AsyncIOMotorDatabase):
+        self.col = db.get_collection(cfg.mongo.collections.chats)
+
+    async def add_message(self, chat_id: str, message: ChatMessage) -> UpdateResult:
+        return await self.col.update_one({
+            "_id": chat_id,
+        }, {"$push": {
+            "messages": message.model_dump(by_alias=True)
+        }})
+
+    async def insert_chat(self, chat: Chat):
+        await self.col.insert_one(chat.model_dump(by_alias=True))
+        return chat
+
+    async def upsert_chat(self, chat_id: str, new_data: dict):
+        return await self.col.update_one(
+            {"_id": chat_id},
+            {"$set": new_data},
+            upsert=True,
+        )
+
+    async def get_chats_by_user_id(self,
+                                   user_id: str,
+                                   *,
+                                   size: int = 20,
+                                   offset: int = 0) -> List[ChatPreviewDTO]:
+        cursor = self.col.find({"user_id": user_id}).skip(offset).limit(size)
+        raw_chats = await cursor.to_list(length=size)
+
+        chat_previews = [
+            ChatPreviewDTO(
+                chat_id=chat["_id"],
+                title=chat["title"],
+                created_at=chat["created_at"],
+                updated_at=chat["updated_at"],
+            ) for chat in raw_chats
+        ]
+
+        return chat_previews
+
+    async def get_chat_by_chat_id(self, chat_id: str):
+
+        raw = await self.col.find_one({"_id": chat_id})
+        return Chat.model_validate(raw) if raw else None

--- a/backend/domains/chat/services.py
+++ b/backend/domains/chat/services.py
@@ -1,0 +1,154 @@
+import asyncio
+import json
+from typing import AsyncGenerator, List, Optional
+
+from fastapi.encoders import jsonable_encoder
+from openai import AsyncOpenAI
+from pymongo.results import UpdateResult
+from app.core.config import AppConfig
+from app.schemas.chat import ChatContentDTO, ChatResponseDTO
+from domains.chat.models import Chat, ChatContent, ChatMessage
+from domains.chat.repositories import ChatPreviewDTO, ChatRepository
+from domains.user.repositories import UserRepository
+from domains.user.services import UserNotFound
+
+import os
+
+
+class ChatNotFound(Exception):
+    pass
+
+
+UPSTAGE_API_KEY = os.getenv("UPSTAGE_API_KEY", "")
+
+
+class ChatService:
+
+    def __init__(self, *, cfg: AppConfig, user_repo: UserRepository,
+                 chat_repo: ChatRepository):
+
+        self.cfg = cfg.user
+        self.user_repo = user_repo
+        self.chat_repo = chat_repo
+
+        self.openai_client = AsyncOpenAI(
+            api_key=UPSTAGE_API_KEY,
+            base_url="https://api.upstage.ai/v1",
+        )
+
+    async def generate_chat_title(self, chat_id: str, question: str) -> str:
+
+        system_prompt = ("다음 사용자 질문에서 짧고 요약된 대화 제목을 한 문장으로 만들어주세요. "
+                         "20자 이내로 간결하게 작성해주세요.")
+
+        response = await self.openai_client.chat.completions.create(
+            model="solar-pro",
+            messages=[{
+                "role": "system",
+                "content": system_prompt
+            }, {
+                "role": "user",
+                "content": question
+            }],
+            temperature=0.3,
+            max_tokens=30,
+        )
+
+        title = response.choices[0].message.content or "새로운 대화"
+        await self.chat_repo.upsert_chat(chat_id=chat_id, new_data={"title": title})
+
+        return title
+
+    async def create_chat(self, chat: Chat) -> Chat:
+        if not await self.user_repo.get_user_by_id(chat.user_id):
+            raise UserNotFound("User does not exist")
+
+        return await self.chat_repo.insert_chat(chat)
+
+    async def add_message(self, *, chat_id: str, message: ChatMessage) -> UpdateResult:
+        if not await self.chat_repo.get_chat_by_chat_id(chat_id):
+            raise ChatNotFound("Chat does not exist")
+
+        return await self.chat_repo.add_message(chat_id, message)
+
+    async def get_chat_list(self, *, user_id: str, size: int,
+                            offset: int) -> List[ChatPreviewDTO]:
+
+        if not await self.user_repo.get_user_by_id(user_id):
+            raise UserNotFound("User does not exist")
+
+        return await self.chat_repo.get_chats_by_user_id(user_id,
+                                                         size=size,
+                                                         offset=offset)
+
+    async def get_chat_detail(self, chat_id: str):
+        chat = await self.chat_repo.get_chat_by_chat_id(chat_id)
+        if not chat:
+            raise ChatNotFound("Chat does not exist")
+        return chat
+
+    async def chat_events(self, *, chat_id: Optional[str], user_id: str, message: str,
+                          run_stream) -> AsyncGenerator[str, None]:
+
+        if not chat_id:
+            chat = await self.create_chat(Chat(user_id=user_id))
+        else:
+            chat = await self.get_chat_detail(chat_id)
+
+        title_task = None
+        if not chat.title:
+            title_task = asyncio.create_task(self.generate_chat_title(chat.id, message))
+
+        user_message = ChatMessage(role="user", content=ChatContent(message=message))
+        print(chat.id)
+        await self.add_message(chat_id=chat.id, message=user_message)
+
+        products = []
+        reply_chunks = []
+
+        initial_response = ChatResponseDTO(
+            chat_id=chat.id,
+            status="pending",
+            content=ChatContentDTO(message="질문을 이해하고 있습니다."))
+
+        data_json = json.dumps(jsonable_encoder(initial_response), ensure_ascii=False)
+        yield f"data: {data_json}\n\n"
+
+        title_yielded = False
+
+        async for _, chunk in run_stream(message, chat.id):
+            payload = ChatResponseDTO(**chunk)
+            data_json = json.dumps(jsonable_encoder(payload), ensure_ascii=False)
+
+            yield f"data: {data_json}\n\n"
+
+            match payload:
+                case ChatResponseDTO(status="response",
+                                     content=ChatContentDTO(products=None,
+                                                            message=reply_chunk)):
+                    reply_chunks.append(reply_chunk)
+
+                case ChatResponseDTO(status="response",
+                                     content=ChatContentDTO(products=_products)):
+                    products = _products
+
+            if not title_yielded and title_task and title_task.done():
+                try:
+                    title = title_task.result()
+                except Exception:
+                    title = "새로운 대화"
+
+                _send_title = ChatResponseDTO(chat_id=chat.id,
+                                              status="title",
+                                              content=ChatContentDTO(message=title))
+                yield f"data: {json.dumps(jsonable_encoder(_send_title), ensure_ascii=False)}\n\n"
+
+                title_yielded = True
+
+        assistant_message = ChatMessage(role="assistant",
+                                        content=ChatContent(
+                                            message="".join(reply_chunks),
+                                            products=products))
+        await self.add_message(chat_id=chat.id, message=assistant_message)
+
+        yield "data: [DONE]\n\n"

--- a/backend/domains/saving/schemas.py
+++ b/backend/domains/saving/schemas.py
@@ -60,6 +60,7 @@ class SavingSearchResult(BaseModel):
     model_config = ConfigDict(populate_by_name=True, strict=False)
 
     def __init__(self, **data):
+        data["interest"] = int(data["interest"])
         super().__init__(product=Saving(**data), **data)
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description
- chats 도메인에 대한 레포지토리 및 서비스 레이어 구현 -> DI 컨테이너에 통합
- 기존 SQLite 기반 DTO 및 I/O 스키마를 MongoDB 구조에 맞춰 리팩토링

## Details
- `ChatRepository`, `ChatService` 정의 및 `AppContainer`에 추가
- FastAPI 엔드포인트에 의존성 주입 방식으로 도메인 연결
- DTO 구조(Pydantic 기반) 리팩토링 및 명확한 MongoDB 컬렉션 구조 반영

## Related
- Closes #17 
- #18